### PR TITLE
Introduce `PomoStamp.timing`

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,9 +1,9 @@
 {
   "version": "2",
   "remote": {
-    "https://deno.land/std@0.177.0/fmt/colors.ts": "938c5d44d889fb82eff6c358bea8baa7e85950a16c9f6dae3ec3a7a729164471",
-    "https://deno.land/std@0.177.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
-    "https://deno.land/std@0.177.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
-    "https://deno.land/std@0.177.0/testing/asserts.ts": "984ab0bfb3faeed92ffaa3a6b06536c66811185328c5dd146257c702c41b01ab"
+    "https://deno.land/std@0.178.0/fmt/colors.ts": "938c5d44d889fb82eff6c358bea8baa7e85950a16c9f6dae3ec3a7a729164471",
+    "https://deno.land/std@0.178.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
+    "https://deno.land/std@0.178.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.178.0/testing/asserts.ts": "984ab0bfb3faeed92ffaa3a6b06536c66811185328c5dd146257c702c41b01ab"
   }
 }

--- a/dev_deps.ts
+++ b/dev_deps.ts
@@ -1,1 +1,1 @@
-export { assertEquals } from "https://deno.land/std@0.177.0/testing/asserts.ts";
+export { assertEquals } from "https://deno.land/std@0.178.0/testing/asserts.ts";

--- a/pomo.ts
+++ b/pomo.ts
@@ -120,4 +120,35 @@ export class PomoStamp {
   public get end(): number {
     return this.start + this.duration;
   }
+
+  public get timing(): Timing {
+    const timing = makeTiming(this.pomo.cycle.total);
+
+    let timeout = this.timeout;
+    let index = this.pomo.cycle.next(this.index);
+
+    for (let i = 0; i < this.pomo.cycle.periods.length; i++) {
+      timing.periods.push({ index, timeout });
+      timeout += this.pomo.cycle.periods[index];
+      index = this.pomo.cycle.next(index);
+    }
+
+    timing.periods = timing.periods.sort((a, b) => a.timeout - b.timeout);
+    return timing;
+  }
+}
+
+/**
+ * A timing is a set of periods and an interval.
+ */
+export interface Timing {
+  periods: {
+    index: number;
+    timeout: number;
+  }[];
+  interval: number;
+}
+
+function makeTiming(interval: number): Timing {
+  return { periods: [], interval };
 }

--- a/pomo_test.ts
+++ b/pomo_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "./dev_deps.ts";
 import { Pomo } from "./pomo.ts";
 import { Cycle } from "./cycle.ts";
+import { DAY, MINUTE } from "./duration.ts";
 
 const TEST_CYCLE = new Cycle([5, 5, 5, 5]);
 const TEST_POMO = new Pomo(TEST_CYCLE, 100, 0);
@@ -52,6 +53,43 @@ Deno.test("PomoStamp.end (2)", () => {
   assertEquals(stamp.end, 110);
 });
 
+Deno.test("PomoStamp.timing - returns correct values for first example", () => {
+  const pomo = new Pomo(
+    new Cycle([5, 10, 15]),
+    0,
+    0,
+  );
+  const stamp = pomo.at(26);
+  const expected = {
+    periods: [
+      { index: 0, timeout: 4 },
+      { index: 1, timeout: 9 },
+      { index: 2, timeout: 19 },
+    ],
+    interval: 30,
+  };
+  assertEquals(stamp.timing, expected);
+});
+
+Deno.test("PomoStamp.timing - returns correct values for second example", () => {
+  const pomo = new Pomo(
+    new Cycle([5, 10, 15]),
+    0,
+    0,
+  );
+
+  const stamp = pomo.at(33);
+  const expected = {
+    periods: [
+      { index: 1, timeout: 2 },
+      { index: 2, timeout: 12 },
+      { index: 0, timeout: 27 },
+    ],
+    interval: 30,
+  };
+  assertEquals(stamp.timing, expected);
+});
+
 Deno.test("Pomo.eternal", () => {
   assertEquals(TEST_POMO.eternal, true);
 });
@@ -59,19 +97,19 @@ Deno.test("Pomo.eternal", () => {
 Deno.test("Pomo.fromPattern", () => {
   const pomo = Pomo.fromPattern({
     pattern: "25w5b25w5b25w10b",
-    dayLength: 60 * 24,
+    dayLength: DAY,
     ref: 0,
-    scale: 1 * 60 * 1e3,
+    scale: MINUTE,
   });
   assertEquals(
     pomo.cycle.periods,
     [
-      1500000,
-      300000,
-      1500000,
-      300000,
-      1500000,
-      600000,
+      1_500_000,
+      300_000,
+      1_500_000,
+      300_000,
+      1_500_000,
+      600_000,
     ],
   );
 });


### PR DESCRIPTION
### Purpose

The purpose of the `PomoStamp.timing` computed property is to calculate values for timeouts and intervals.

For example,

```ts
start(stamp.timing, (i: number) => {
  console.log(i % 2 === 0 ? "Work!" : "Break!"));
});

function start(
  timing: Timing,
  fn: (i: number) => void,
  setTimeoutFn = setTimeout,
  setIntervalFn = setInterval
): number[] {
  const ids: number[] = [];
  for (const period of timing.periods) {
    const id = setTimeoutFn(() => {
      fn(period.index);
      ids.push(setIntervalFn(() => fn(period.index), timing.interval));
    }, period.timeout);
    ids.push(id);
  }
  return ids;
}
```

### Changelog

- Add `timing` computed property to `PomoStamp`
- `https://deno.land/std@0.177.0` => `https://deno.land/std@0.178.0`