### PR TITLE
Server: Refactor `/` endpoint

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -41,7 +41,9 @@ function handle(request: Request): Response {
   switch (true) {
     case url.pathname === "/": {
       return pomo.json({
-        pattern: url.searchParams.get("pattern") ?? "25 5 25 5 25 10",
+        patterns: url.searchParams.get("patterns") ??
+          url.searchParams.get("p") ??
+          POMO_PATTERNS,
         timestamp: url.searchParams.get("timestamp") || undefined,
         format: url.searchParams.get("format") || undefined,
       });

--- a/server/pomo/format_message.ts
+++ b/server/pomo/format_message.ts
@@ -10,7 +10,7 @@ export function formatMessage(
   const currentPeriodDuration = collection.data[name].cycle.periods[period];
   const nextPeriodDuration = collection.data[name].cycle
     .periods[collection.data[name].cycle.next(period)];
-  return `🍅 @pomo-${name} NOW: **${
+  return `🍅 <@&${name}> NOW: **${
     format(currentPeriodDuration, "HH:mm")
   }** ${currentPeriodStatus}; NEXT: **${
     format(nextPeriodDuration, "HH:mm")


### PR DESCRIPTION
### Changelog

#### `server/main.ts`

- Replace `pattern` URL query parameter with `patterns`
  - By default, the value is referenced via [`POMO_PATTERNS`](https://github.com/EthanThatOneKid/pomo/blob/80298ae0d5446e267ab07f7f30f7203689e866c8/server/env.ts#LL2C14-L2C27).
  - Bonus: New alias URL query parameter `p`. The value of `patterns` URL query parameter takes preference in the presence of both `patterns` and `p`.

#### `server/pomo/format_message.ts`

- Replace `@pomo-${name}` with `<@&${name}>`, expecting `name` to now hold the value of the respective Discord role ID.

#### `server/pomo/get.ts`

- Replace `GetPomoInput.pattern` with `GetPomoInput.patterns`
- Pluralize `GetPomoOutput`

Resolves #10