### PR TITLE
Catch internal server errors gracefully

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,9 +1,9 @@
 {
   "version": "2",
   "remote": {
-    "https://deno.land/std@0.186.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
-    "https://deno.land/std@0.186.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
-    "https://deno.land/std@0.186.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
-    "https://deno.land/std@0.186.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f"
+    "https://deno.land/std@0.192.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
+    "https://deno.land/std@0.192.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
+    "https://deno.land/std@0.192.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.192.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f"
   }
 }

--- a/dev_deps.ts
+++ b/dev_deps.ts
@@ -1,1 +1,1 @@
-export { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
+export { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";

--- a/server/deps.ts
+++ b/server/deps.ts
@@ -1,3 +1,4 @@
 import "https://deno.land/std@0.186.0/dotenv/load.ts";
 
+export { retry } from "https://deno.land/std@0.170.0/async/mod.ts";
 export { serve } from "https://deno.land/std@0.186.0/http/server.ts";

--- a/server/deps.ts
+++ b/server/deps.ts
@@ -1,4 +1,4 @@
-import "https://deno.land/std@0.186.0/dotenv/load.ts";
+import "https://deno.land/std@0.192.0/dotenv/load.ts";
 
-export { retry } from "https://deno.land/std@0.170.0/async/mod.ts";
-export { serve } from "https://deno.land/std@0.186.0/http/server.ts";
+export { retry } from "https://deno.land/std@0.192.0/async/mod.ts";
+export { serve } from "https://deno.land/std@0.192.0/http/server.ts";

--- a/server/main.ts
+++ b/server/main.ts
@@ -19,12 +19,11 @@ if (import.meta.main) {
     timestamp,
     async (name, period) => {
       const response = await retry(
-        () => {
-          return discord.webhook({
+        () =>
+          discord.webhook({
             url: DISCORD_WEBHOOK_URL,
             content: pomo.formatMessage(collection, name, period),
-          });
-        },
+          }),
         {
           multiplier: 2,
           maxTimeout: 60000,
@@ -42,8 +41,8 @@ if (import.meta.main) {
 
   await serve(handle, {
     port: PORT,
-    onListen({ port }) {
-      console.log(`Listening on http://localhost:${port}`);
+    onListen() {
+      console.log(`Listening on http://localhost:${PORT}`);
     },
   });
 


### PR DESCRIPTION
I implemented a retry function in case the initial error was a fluke. In case it continues to error, our server now errors by printing the error to the console instead of exiting the program.

Resolves #28. cc @diamondburned :)